### PR TITLE
Parse JSON path operators

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,8 @@ pub enum Operator {
     Arithmetic(ArithmeticOperator),
     Logical(LogicalOperator),
     Comparison(ComparisonOperator),
-    Bitwise(BitwiseOperator)
+    Bitwise(BitwiseOperator),
+    Json(JsonOperator)
 }
 
 #[derive(Debug,PartialEq)]
@@ -81,8 +82,14 @@ pub enum BitwiseOperator {
 }
 
 #[derive(Debug,PartialEq)]
+pub enum JsonOperator {
+    SpecifiedPath, // #>
+    SpecifiedPathAsText // #>>
+}
+
+#[derive(Debug,PartialEq)]
 pub enum LiteralValueTypeIndicator {
-    Binary,              // BINARAY
+    Binary,              // BINARY
     Date,                // DATE
     Time,                // TIME
     Timestamp,           // TIMESTAMP

--- a/src/sanitizer.rs
+++ b/src/sanitizer.rs
@@ -454,4 +454,12 @@ mod tests {
             sql
         );
     }
+
+    #[test]
+    fn test_json_operations() {
+        assert_eq!(
+            sanitize_string("SELECT table.*, NULLIF((table2.json_col #>> '{obj1,obj2}')::float, 0) FROM table".to_string()),
+            "SELECT table.*, NULLIF((table2.json_col #>> ?)::float, 0) FROM table"
+        )
+    }
 }

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -1,4 +1,4 @@
-use super::{Keyword,Token,LiteralValueTypeIndicator,Operator,ArithmeticOperator,ComparisonOperator,LogicalOperator,BitwiseOperator,Sql};
+use super::{Keyword,Token,LiteralValueTypeIndicator,Operator,ArithmeticOperator,ComparisonOperator,LogicalOperator,BitwiseOperator,JsonOperator,Sql};
 
 pub struct SqlWriter {
     pub sql: Sql
@@ -48,6 +48,9 @@ impl SqlWriter {
                 &Token::Operator(Operator::Bitwise(BitwiseOperator::RightShift)) => out.push_str(">>"),
                 &Token::Operator(Operator::Bitwise(BitwiseOperator::And)) => out.push('&'),
                 &Token::Operator(Operator::Bitwise(BitwiseOperator::Or)) => out.push('|'),
+                // JSON operator
+                &Token::Operator(Operator::Json(JsonOperator::SpecifiedPath)) => out.push_str("#>"),
+                &Token::Operator(Operator::Json(JsonOperator::SpecifiedPathAsText)) => out.push_str("#>>"),
                 // Keywords
                 &Token::Keyword(Keyword::Select) => out.push_str("SELECT"),
                 &Token::Keyword(Keyword::From) => out.push_str("FROM"),
@@ -213,6 +216,14 @@ mod tests {
     #[test]
     fn test_write_bitwise_operators() {
         let sql = "<< >> & |";
+        let written = helpers::lex_and_write(sql.to_string());
+
+        assert_eq!(written, sql);
+    }
+
+    #[test]
+    fn test_write_json_operators() {
+        let sql = "#> #>>";
         let written = helpers::lex_and_write(sql.to_string());
 
         assert_eq!(written, sql);


### PR DESCRIPTION
JSON path operators were parsed as comments, making all the information
disappear until a comment break character appeared. JSON path operators
are now supported and shown after parsing.