### PR TITLE
Re-add crates.io badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # SQL lexer
 
 [![Build Status](https://appsignal.semaphoreci.com/badges/sql_lexer/branches/main.svg)](https://appsignal.semaphoreci.com/projects/sql_lexer)
-[Crate](https://crates.io/crates/sql_lexer)
+[![Crate](https://img.shields.io/crates/v/sql_lexer.svg)](https://crates.io/crates/sql_lexer)
 
 Rust library to lex and sanitize SQL. To lex a query and write back to a string:
 


### PR DESCRIPTION
The shields.io crate badge appears to be working again. Re-add badge with working URL that was removed in f9acffa4c52c42d85a041455bc224654729b1dbe.