### PR TITLE
Sanitise within functions

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -12,6 +12,8 @@ blocks:
       prologue:
         commands:
           - checkout
+          - rustup toolchain install nightly
+          - rustup default nightly
       jobs:
         - name: Formatter and linter
           commands:
@@ -20,5 +22,4 @@ blocks:
             - cargo clippy
         - name: Build and tests
           commands:
-            - rustup toolchain install nightly
-            - cargo +nightly test --verbose
+            - cargo test --verbose

--- a/src/sanitizer.rs
+++ b/src/sanitizer.rs
@@ -1,6 +1,6 @@
 use super::{Keyword, Sql, Token};
 
-#[derive(Debug, PartialEq, Copy, Clone)]
+#[derive(Debug, PartialEq)]
 enum State {
     Default,
     ComparisonOperator,
@@ -35,9 +35,7 @@ impl SqlSanitizer {
                 break;
             }
 
-            let prev_state = state;
-
-            match self.sql.tokens[pos] {
+            match &self.sql.tokens[pos] {
                 // Determine if we want to change or keep state
                 Token::Operator(_) if state != State::JoinOn => state = State::ComparisonOperator,
                 Token::Keyword(Keyword::Values) => state = State::InsertValues,
@@ -53,7 +51,9 @@ impl SqlSanitizer {
                     state = State::KeywordScopeStarted
                 }
                 Token::Keyword(Keyword::Insert) | Token::Keyword(Keyword::Into) => (),
-                Token::Keyword(_) if state == State::KeywordScopeStarted => state = State::KeywordScopeStarted,
+                Token::Keyword(_) if state == State::KeywordScopeStarted => {
+                    state = State::KeywordScopeStarted
+                }
                 Token::Keyword(_) => state = State::Keyword,
                 Token::LiteralValueTypeIndicator(_) => state = State::LiteralValueTypeIndicator,
                 Token::ParentheseOpen if state == State::ComparisonOperator => {
@@ -74,10 +74,10 @@ impl SqlSanitizer {
                 Token::ParentheseClose | Token::SquareBracketClose => state = State::Default,
                 Token::Dot if state == State::JoinOn => (),
                 // This is content we might want to sanitize
-                Token::SingleQuoted(_)
+                token @ (Token::SingleQuoted(_)
                 | Token::DoubleQuoted(_)
                 | Token::Numeric(_)
-                | Token::Null => {
+                | Token::Null) => {
                     match state {
                         State::ComparisonOperator
                         | State::InsertValues
@@ -85,7 +85,19 @@ impl SqlSanitizer {
                         | State::KeywordScopeStarted
                         | State::Between
                         | State::LiteralValueTypeIndicator => {
-                            self.placeholder(pos);
+                            // Double quoted might (standard SQL) or might not (MySQL) be an identifier,
+                            // but if it's a component in a dotted path, then we know it's part of an
+                            // identifier and we should definitely not replace it with a placeholder.
+                            match token {
+                                Token::DoubleQuoted(_) => {
+                                    if !(self.sql.tokens.get(pos - 1) == Some(&Token::Dot)
+                                        || self.sql.tokens.get(pos + 1) == Some(&Token::Dot))
+                                    {
+                                        self.placeholder(pos)
+                                    }
+                                }
+                                _ => self.placeholder(pos),
+                            }
                         }
                         State::ComparisonScopeStarted | State::ArrayStarted => {
                             // We're in an IN () or ARRAY[] and it starts with content. Remove everything until
@@ -113,11 +125,6 @@ impl SqlSanitizer {
                 // Reset state to default if there were no matches
                 _ => state = State::Default,
             }
-
-            println!(
-                "prev: {:?}, here: {:?}, now: {:?}",
-                prev_state, self.sql.tokens[pos], state
-            );
 
             pos += 1;
         }
@@ -541,10 +548,7 @@ mod tests {
     #[test]
     fn test_remove_trailing_comments_multiline() {
         assert_eq!(
-            sanitize_string(
-                "SELECT table.* FROM table; /* trace: a1b2c3d4e5f6 */"
-                    .to_string()
-            ),
+            sanitize_string("SELECT table.* FROM table; /* trace: a1b2c3d4e5f6 */".to_string()),
             "SELECT table.* FROM table;"
         );
     }
@@ -552,10 +556,7 @@ mod tests {
     #[test]
     fn test_remove_trailing_comments_inline() {
         assert_eq!(
-            sanitize_string(
-                "SELECT table.* FROM table; -- trace: a1b2c3d4e5f6"
-                    .to_string()
-            ),
+            sanitize_string("SELECT table.* FROM table; -- trace: a1b2c3d4e5f6".to_string()),
             "SELECT table.* FROM table;"
         );
     }
@@ -563,10 +564,7 @@ mod tests {
     #[test]
     fn test_remove_trailing_comments_before_semicolon() {
         assert_eq!(
-            sanitize_string(
-                "SELECT table.* FROM table /* trace: a1b2c3d4e5f6 */;"
-                    .to_string()
-            ),
+            sanitize_string("SELECT table.* FROM table /* trace: a1b2c3d4e5f6 */;".to_string()),
             "SELECT table.* FROM table;"
         );
     }
@@ -582,12 +580,34 @@ mod tests {
     }
 
     #[test]
+    fn test_select_jsonb_extract_path_quoted_identifier() {
+        assert_eq!(
+            sanitize_string(
+                "SELECT jsonb_extract_path(\"table\".\"data\", 'foo', 22) FROM \"table\";"
+                    .to_string()
+            ),
+            "SELECT jsonb_extract_path(\"table\".\"data\", ?, ?) FROM \"table\";"
+        );
+    }
+
+    #[test]
     fn test_where_jsonb_extract_path() {
         assert_eq!(
             sanitize_string(
-                "SELECT id FROM table WHERE jsonb_extract_path(table.data, 'foo', 22) == 'bar';".to_string()
+                "SELECT id FROM table WHERE jsonb_extract_path(table.data, 'foo', 22) = 'bar';"
+                    .to_string()
             ),
-            "SELECT id FROM table WHERE jsonb_extract_path(table.data, ?, ?) == ?;"
+            "SELECT id FROM table WHERE jsonb_extract_path(table.data, ?, ?) = ?;"
+        );
+    }
+
+    #[test]
+    fn test_where_quoted_identifier_in_parenthesis() {
+        assert_eq!(
+            sanitize_string(
+                r#"SELECT "table"."id" FROM "table" WHERE ("table"."data" = 'foo');"#.to_string()
+            ),
+            r#"SELECT "table"."id" FROM "table" WHERE ("table"."data" = ?);"#
         );
     }
 }


### PR DESCRIPTION
Fixes #26 and fixes #11. For a lenient enough definition of "fixed", anyway.

For #26, I opted to only remove _trailing_ comments. This should be enough for the cases I've seen in the real world, including that of the affected user, while keeping valuable comments around. Let me know if you disagree.

For #11, there is no way to know the meaning of a lone double-quoted string without knowing if the database is or isn't MySQL. But we can do better for the situation where the double-quoted string is part of a broader dotted-identifier sequence. This should be a _de facto_ fix for ORM-generated queries, which usually disambiguate the table in this manner.

### [Remove trailing comments](https://github.com/appsignal/sql_lexer/commit/d629f5a8f259e7cfeaf64aa4fb9142e62d59afc3) 

It's common for the database adapter or its instrumentation to add
a comment to the query with contextual information, such as the
database instance that it was performed again or the trace ID.

This removes comments located at the very end of the trace, which
is where these comments are usually found. Other comments are
preserved, as they often contain user-provided context about the
query itself.

### [Sanitize arguments within functions](https://github.com/appsignal/sql_lexer/commit/a3379e067faf0179b4e15ee9ed07e351c96cd728)

Do not lose the KeywordScopeStarted state when encountering more
keywords.

### [Respect dotted quoted identifiers in parenthesis](https://github.com/appsignal/sql_lexer/commit/3141cec6b5badf48ba4bdb19522a9a556628f796)

When a double-quoted value is found, it is unclear whether to treat
it as a string (MySQL) or as an identifier (standard SQL), so the
placeholder logic must treat it as a string. However, if it is
preceded or followed by a dot, then we know it must be an identifier,
and we should not replace it with a placeholder.