### PR TITLE
Test empty string sanitization

### DIFF
--- a/src/sanitizer.rs
+++ b/src/sanitizer.rs
@@ -152,6 +152,11 @@ mod tests {
     use super::super::sanitize_string;
 
     #[test]
+    fn test_empty() {
+        assert_eq!(sanitize_string("".to_string()), "")
+    }
+
+    #[test]
     fn test_select_where_single_quote() {
         assert_eq!(
             sanitize_string(


### PR DESCRIPTION
See [Slack conversation](https://appsignal.slack.com/archives/CNPP953E2/p1706725098166539?thread_ts=1706724079.347649&cid=CNPP953E2). Test does pass now, but didn't pass [before the comment sanitization logic was changed](https://github.com/appsignal/sql_lexer/commit/283de74fab43160c3e05b278428b878d667cd9a5).