### PR TITLE
Fix TRUE and FALSE sanitization

### DIFF
--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -363,6 +363,10 @@ impl SqlLexer {
                         }
                         // Null
                         s if s.eq_ignore_ascii_case("NULL") => Token::Null,
+                        // True
+                        s if s.eq_ignore_ascii_case("TRUE") => Token::True,
+                        // False
+                        s if s.eq_ignore_ascii_case("FALSE") => Token::False,
                         // Other keyword
                         _ => Token::Keyword(Keyword::Other(BufferSlice::new(
                             current_byte_offset,
@@ -1199,6 +1203,27 @@ mod tests {
             Token::Null,
             Token::Space,
             Token::Null,
+        ];
+
+        assert_eq!(lexer.lex().tokens, expected);
+    }
+
+    #[test]
+    fn test_true_false() {
+        let sql = "TRUE true True FALSE false False".to_string();
+        let lexer = SqlLexer::new(sql);
+        let expected = vec![
+            Token::True,
+            Token::Space,
+            Token::True,
+            Token::Space,
+            Token::True,
+            Token::Space,
+            Token::False,
+            Token::Space,
+            Token::False,
+            Token::Space,
+            Token::False,
         ];
 
         assert_eq!(lexer.lex().tokens, expected);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,6 +139,8 @@ pub enum Token {
     Semicolon,
     Placeholder,
     Null,
+    True,
+    False,
     NumberedPlaceholder(BufferSlice),
     Unknown(char),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -138,6 +138,7 @@ pub enum Token {
     Colon,
     Semicolon,
     Placeholder,
+    Ellipsis,
     Null,
     True,
     False,

--- a/src/sanitizer.rs
+++ b/src/sanitizer.rs
@@ -68,7 +68,43 @@ impl SqlSanitizer {
                 }
                 Token::Comma if state == State::InsertValuesJustClosed => (),
                 Token::ParentheseOpen if state == State::InsertValuesJustClosed => {
-                    state = State::InsertValues
+                    // We're past the first insert values clause. Remove every parentheses
+                    // group and replace them with an ellipsis.
+                    let start_pos = pos;
+                    let mut in_parentheses = true;
+                    let mut kept = 0;
+
+                    loop {
+                        if pos + kept >= self.sql.tokens.len() {
+                            break;
+                        }
+
+                        let keep = match self.sql.tokens[pos + kept] {
+                            Token::ParentheseClose => {
+                                in_parentheses = false;
+                                false
+                            }
+                            Token::ParentheseOpen => {
+                                in_parentheses = true;
+                                false
+                            }
+                            _ if in_parentheses => false,
+                            Token::Comma => true,
+                            Token::Space => true,
+                            _ => break,
+                        };
+
+                        if keep {
+                            kept += 1;
+                        } else {
+                            self.remove(pos + kept);
+                            while kept > 0 {
+                                kept -= 1;
+                                self.remove(pos + kept);
+                            }
+                        }
+                    }
+                    self.sql.tokens.insert(start_pos, Token::Ellipsis);
                 }
                 Token::ParentheseClose | Token::SquareBracketClose => state = State::Default,
                 Token::Dot if state == State::JoinOn => (),
@@ -487,7 +523,7 @@ mod tests {
     fn test_insert_multiple_values() {
         assert_eq!(
             sanitize_string("INSERT INTO `table` (`field1`, `field2`) VALUES ('value', 1, -1.0, 'value'),('value', 1, -1.0, 'value'),('value', 1, -1.0, 'value');".to_string()),
-            "INSERT INTO `table` (`field1`, `field2`) VALUES (?, ?, ?, ?),(?, ?, ?, ?),(?, ?, ?, ?);"
+            "INSERT INTO `table` (`field1`, `field2`) VALUES (?, ?, ?, ?),...;"
         );
     }
 
@@ -495,7 +531,7 @@ mod tests {
     fn test_insert_multiple_values_with_spaces() {
         assert_eq!(
             sanitize_string("INSERT INTO `table` (`field1`, `field2`) VALUES ('value', 1, -1.0, 'value'), ('value', 1, -1.0, 'value'), ('value', 1, -1.0, 'value');".to_string()),
-            "INSERT INTO `table` (`field1`, `field2`) VALUES (?, ?, ?, ?), (?, ?, ?, ?), (?, ?, ?, ?);"
+            "INSERT INTO `table` (`field1`, `field2`) VALUES (?, ?, ?, ?), ...;"
         );
     }
 
@@ -513,7 +549,7 @@ mod tests {
             sanitize_string(
                 "INSERT INTO \"table\" (\"field1\", \"field2\") VALUES (1, NULL), (NULL, 1), (NULL, NULL), (1, 1);".to_string()
             ),
-            "INSERT INTO \"table\" (\"field1\", \"field2\") VALUES (?, ?), (?, ?), (?, ?), (?, ?);"
+            "INSERT INTO \"table\" (\"field1\", \"field2\") VALUES (?, ?), ...;"
         );
     }
 
@@ -521,9 +557,19 @@ mod tests {
     fn test_insert_true_false() {
         assert_eq!(
             sanitize_string(
-                "INSERT INTO \"table\" (\"field1\", \"field2\") VALUES (1, 2), (TRUE, FALSE), (FALSE, TRUE), (2, 1);".to_string()
+                "INSERT INTO \"table\" (\"field1\", \"field2\") VALUES (TRUE, FALSE), (1, 2), (FALSE, TRUE), (2, 1);".to_string()
             ),
-            "INSERT INTO \"table\" (\"field1\", \"field2\") VALUES (?, ?), (?, ?), (?, ?), (?, ?);"
+            "INSERT INTO \"table\" (\"field1\", \"field2\") VALUES (?, ?), ...;"
+        );
+    }
+
+    #[test]
+    fn test_insert_many_on_conflict() {
+        assert_eq!(
+            sanitize_string(
+                "INSERT INTO \"table\" (\"field1\", \"field2\") VALUES (TRUE, FALSE), (1, 2), (FALSE, TRUE), (2, 1) ON CONFLICT DO NOTHING RETURNING \"field1\";".to_string()
+            ),
+            "INSERT INTO \"table\" (\"field1\", \"field2\") VALUES (?, ?), ... ON CONFLICT DO NOTHING RETURNING \"field1\";"
         );
     }
 

--- a/src/sanitizer.rs
+++ b/src/sanitizer.rs
@@ -76,7 +76,9 @@ impl SqlSanitizer {
                 token @ (Token::SingleQuoted(_)
                 | Token::DoubleQuoted(_)
                 | Token::Numeric(_)
-                | Token::Null) => {
+                | Token::Null
+                | Token::True
+                | Token::False) => {
                     match state {
                         State::ComparisonOperator
                         | State::InsertValues
@@ -509,9 +511,19 @@ mod tests {
     fn test_insert_null() {
         assert_eq!(
             sanitize_string(
-                "INSERT INTO \"table\" (\"field1\", \"field2\") VALUES (NULL, 1);".to_string()
+                "INSERT INTO \"table\" (\"field1\", \"field2\") VALUES (1, NULL), (NULL, 1), (NULL, NULL), (1, 1);".to_string()
             ),
-            "INSERT INTO \"table\" (\"field1\", \"field2\") VALUES (?, ?);"
+            "INSERT INTO \"table\" (\"field1\", \"field2\") VALUES (?, ?), (?, ?), (?, ?), (?, ?);"
+        );
+    }
+
+    #[test]
+    fn test_insert_true_false() {
+        assert_eq!(
+            sanitize_string(
+                "INSERT INTO \"table\" (\"field1\", \"field2\") VALUES (1, 2), (TRUE, FALSE), (FALSE, TRUE), (2, 1);".to_string()
+            ),
+            "INSERT INTO \"table\" (\"field1\", \"field2\") VALUES (?, ?), (?, ?), (?, ?), (?, ?);"
         );
     }
 

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -171,6 +171,8 @@ impl SqlWriter {
                 Token::Semicolon => out.push(';'),
                 Token::Placeholder => out.push('?'),
                 Token::Null => out.push_str("NULL"),
+                Token::True => out.push_str("TRUE"),
+                Token::False => out.push_str("FALSE"),
                 Token::NumberedPlaceholder(ref slice) => {
                     out.push_str(self.sql.buffer_content(slice));
                 }

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -170,6 +170,7 @@ impl SqlWriter {
                 Token::Colon => out.push(':'),
                 Token::Semicolon => out.push(';'),
                 Token::Placeholder => out.push('?'),
+                Token::Ellipsis => out.push_str("..."),
                 Token::Null => out.push_str("NULL"),
                 Token::True => out.push_str("TRUE"),
                 Token::False => out.push_str("FALSE"),


### PR DESCRIPTION
These changes should fix the sanitization issues encountered by the customer [in this Slack thread](https://appsignal.slack.com/archives/C0DTGLNGN/p1722490955185779).

### [Fix sanitization of TRUE and FALSE values](https://github.com/appsignal/sql_lexer/commit/4e5121c41984c73311833c0056da938562834f30)

When a TRUE or FALSE value was encountered in a sanitisation context,
the sanitiser would not sanitise them, but also it would forget that
it was a sanitisation context and leave any following values
unsanitised.

### [Omit repeated VALUES groups](https://github.com/appsignal/sql_lexer/commit/e637f54f1a2b27d4752f3e788b356ab416dcce1b)

When an `INSERT INTO (...) VALUES (...)` has many parenthesis groups
(`VALUES (...), (...)`) omit all but the first, replacing the rest
with an ellipsis.

