### PR TITLE
Fix quadratic `INSERT INTO ... VALUES` sanitisation performance

### DIFF
--- a/src/bin/bench.rs
+++ b/src/bin/bench.rs
@@ -1,0 +1,22 @@
+fn long_insert_into_values_query(rows: usize) -> String {
+    let mut query = r#"INSERT INTO "table_name" ("one","two","three") VALUES "#.to_owned();
+    for i in 0..rows {
+        query.push_str(&format!("({}, {}, {}),", i, i + 1, i + 2));
+    }
+    query.push_str("(0, 0, 0);");
+    query
+}
+
+extern crate sql_lexer;
+
+fn main() {
+    for rows in [200, 2000, 20000] {
+        println!("Sanitising long_insert_into_values_query with {rows} rows");
+        let query = long_insert_into_values_query(rows);
+        let start = std::time::Instant::now();
+        let output = sql_lexer::sanitize_string(query);
+        let elapsed = start.elapsed();
+        println!("Output: {}", output);
+        println!("Elapsed: {:?}", elapsed);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,8 +137,12 @@ pub enum Token {
     SquareBracketClose,
     Colon,
     Semicolon,
+    // Used by the sanitizer to replace values
     Placeholder,
+    // Used by the sanitizer to replace repeated value lists
     Ellipsis,
+    // Used by the sanitizer to remove tokens
+    None,
     Null,
     True,
     False,

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -171,6 +171,7 @@ impl SqlWriter {
                 Token::Semicolon => out.push(';'),
                 Token::Placeholder => out.push('?'),
                 Token::Ellipsis => out.push_str("..."),
+                Token::None => {}
                 Token::Null => out.push_str("NULL"),
                 Token::True => out.push_str("TRUE"),
                 Token::False => out.push_str("FALSE"),


### PR DESCRIPTION
Fixes https://github.com/appsignal/appsignal-elixir/issues/975. I introduced this bug in #32.

---

### [Add simple benchmark tool](https://github.com/appsignal/sql_lexer/commit/f17159a9ac82cd4807179d896d51ef4e89c91ec2)

Since `#[bench]` is nightly-only, add a simple binary that can be
modified to test the performance of specific queries as needed.

### [Avoid `Vec::remove` with `None` token](https://github.com/appsignal/sql_lexer/commit/6ac74068b8c443ea300e24d02b30406e89de509a)

Using `Vec::remove(i)` causes the `n` tokens between position `i` and
the end of the vector to be shifted, which is an `O(n)` operation.

When done in a loop, as it is done in our `INSERT INTO ... VALUES`
repeated list sanitisation, it makes the overall performance `O(n^2)`.

To avoid using `Vec::remove`, implement a `Token::None` value that
represents a "non-token", a gap to be ignored in the token list.

Replace calls to `Vec::remove(i)` with replacing the token at
position `i` with `Token::None`.

Replace calls to `Vec::insert` for the same reason -- luckily, when
we insert a token, it's a replacement for a different token, so it's
possible to rewrite them in that manner. These are rarely done in a
loop, though, so the impact on sanitisation performance is much more
limited.